### PR TITLE
feat: refresh desire section gradient

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -18,7 +18,6 @@
   --muted-foreground: 215 12% 32%;
   --accent: 208 46% 89%;
   --accent-foreground: 224 64% 33%;
-  --desire-bg: 210 9% 87%;
   --destructive: 0 72% 51%;
   --destructive-foreground: 0 0% 100%;
   --border: 210 12% 80%;
@@ -77,7 +76,6 @@
   --sidebar-accent-foreground: 210 40% 96%;
   --sidebar-border: 218 24% 28%;
   --sidebar-ring: 222 73% 56%;
-  --desire-bg: 215 14% 34%;
 }
 
 @layer base {
@@ -100,8 +98,3 @@
   }
 }
 
-@layer utilities {
-  .bg-desire {
-    background-color: hsl(var(--desire-bg));
-  }
-}

--- a/components/landing/InfoCard.tsx
+++ b/components/landing/InfoCard.tsx
@@ -8,13 +8,13 @@ interface InfoCardProps {
 
 export function InfoCard({ icon, title, description }: InfoCardProps) {
   return (
-    <div className="flex flex-col gap-4 rounded-2xl border border-border bg-card/90 p-6 shadow-lg backdrop-blur">
+    <div className="flex flex-col gap-4 rounded-2xl border border-border/70 bg-card/95 p-6 shadow-lg backdrop-blur">
       <div className="text-3xl text-primary" aria-hidden>
         {icon}
       </div>
       <div>
-        <h3 className="text-xl font-semibold text-foreground">{title}</h3>
-        <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+        <h3 className="text-xl font-semibold text-card-foreground">{title}</h3>
+        <p className="mt-2 text-sm text-card-foreground/80">{description}</p>
       </div>
     </div>
   );

--- a/components/landing/LandingPage.tsx
+++ b/components/landing/LandingPage.tsx
@@ -155,14 +155,21 @@ export function LandingPage() {
       </section>
 
       {/* Desire */}
-      <section className="bg-desire py-20 transition-colors duration-200" aria-labelledby="desire-section">
+      <section
+        className="relative isolate overflow-hidden py-20 transition-colors duration-200"
+        aria-labelledby="desire-section"
+      >
+        <div className="absolute inset-0 -z-10 bg-gradient-to-b from-accent/40 via-background/60 to-accent/10 dark:from-accent/35 dark:via-slate-900/70 dark:to-slate-950" />
         <div className="mx-auto w-full max-w-6xl px-6">
           <div className="mx-auto max-w-2xl text-center">
             <p className="text-sm font-semibold uppercase tracking-[0.3em] text-primary">Desire</p>
-            <h2 id="desire-section" className="mt-3 text-3xl font-bold sm:text-4xl">
+            <h2
+              id="desire-section"
+              className="mt-3 text-3xl font-bold text-slate-900 dark:text-slate-100 sm:text-4xl"
+            >
               양성화의 장점과 확실한 절차
             </h2>
-            <p className="mt-4 text-base text-muted-foreground">
+            <p className="mt-4 text-base text-slate-700 dark:text-slate-200">
               30년 노하우로 진행되는 맞춤 컨설팅과 함께 합법화의 모든 과정을 한 번에 해결하세요.
             </p>
           </div>
@@ -172,7 +179,9 @@ export function LandingPage() {
             ))}
           </div>
           <div className="mt-16 space-y-6">
-            <h3 className="text-center text-2xl font-semibold text-foreground">양성화 절차 타임라인</h3>
+            <h3 className="text-center text-2xl font-semibold text-slate-900 dark:text-slate-100">
+              양성화 절차 타임라인
+            </h3>
             <Timeline steps={timelineSteps} />
           </div>
         </div>

--- a/components/landing/Timeline.tsx
+++ b/components/landing/Timeline.tsx
@@ -7,10 +7,10 @@ export function Timeline({ steps }: TimelineProps) {
     <ol className="relative mx-auto max-w-4xl space-y-6 border-l border-border/70 pl-6">
       {steps.map((step, index) => (
         <li key={step} className="ml-4">
-          <div className="absolute -left-[11px] mt-1 h-5 w-5 rounded-full border-2 border-primary bg-background" aria-hidden />
-          <div className="rounded-xl border border-border bg-card p-4 shadow-sm bg-opacity-80">
+          <div className="absolute -left-[11px] mt-1 h-5 w-5 rounded-full border-2 border-primary bg-card" aria-hidden />
+          <div className="rounded-xl border border-border/70 bg-card/95 p-4 shadow-sm backdrop-blur">
             <p className="text-sm font-semibold text-primary">STEP {index + 1}</p>
-            <p className="mt-1 text-base text-foreground">{step}</p>
+            <p className="mt-1 text-base text-card-foreground">{step}</p>
           </div>
         </li>
       ))}


### PR DESCRIPTION
## Summary
- wrap the Desire section in a gradient-backed container to deliver the requested pastel-to-navy contrast across light and dark themes
- tune InfoCard and Timeline surfaces/typography so cards stay legible atop the refreshed background
- remove the now-unused `bg-desire` utility from the global stylesheet

## Testing
- ⚠️ `npm run lint` *(Next.js prompts for ESLint setup because no config exists; aborted to avoid generating new config files)*

------
https://chatgpt.com/codex/tasks/task_e_68d299f0b53483238443af7068891818