### PR TITLE
Fix Kakao callback URL to respect deployment environment

### DIFF
--- a/app/api/auth/callback/kakao/route.ts
+++ b/app/api/auth/callback/kakao/route.ts
@@ -1,7 +1,10 @@
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
-import { createSupabaseAdminClient } from '../../../supabase/admin';
+import { assertNextAuthEnv } from '@/lib/env';
+import { createSupabaseAdminClient } from '@/supabase/admin';
+
+assertNextAuthEnv();
 
 export async function GET(request: Request) {
   const requestUrl = new URL(request.url);

--- a/components/auth/AuthPanel.tsx
+++ b/components/auth/AuthPanel.tsx
@@ -4,8 +4,9 @@ import type { User } from '@supabase/auth-helpers-nextjs';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import { useRouter } from 'next/navigation';
 import { useCallback, useMemo, useState } from 'react';
+import { getKakaoCallbackUrl } from '@/lib/env';
+import type { UserProfile } from '@/types/profile';
 import { Button } from '../ui/button';
-import type { UserProfile } from '../../types/profile';
 
 function resolveDisplayName(sessionUser: User | null, profile: UserProfile | null) {
   if (profile?.full_name) return profile.full_name;
@@ -26,19 +27,20 @@ export default function AuthPanel({ sessionUser, profile }: Props) {
 
   const handleSignIn = useCallback(async () => {
     setLoading(true);
-    const origin =
-      process.env.NEXTAUTH_URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? window.location.origin;
-    const cleanOrigin = origin.endsWith('/') ? origin.slice(0, -1) : origin;
 
-    await supabase.auth.signInWithOAuth({
-      provider: 'kakao',
-      options: {
-        redirectTo: `${cleanOrigin}/auth/callback`,
-        queryParams: {
-          scope: 'account_email'
+    try {
+      await supabase.auth.signInWithOAuth({
+        provider: 'kakao',
+        options: {
+          redirectTo: getKakaoCallbackUrl(),
+          queryParams: {
+            scope: 'account_email'
+          }
         }
-      }
-    });
+      });
+    } finally {
+      setLoading(false);
+    }
   }, [supabase]);
 
   const handleSignOut = useCallback(async () => {

--- a/components/landing/LoginModal.tsx
+++ b/components/landing/LoginModal.tsx
@@ -2,6 +2,7 @@
 
 import { Dialog, Transition } from '@headlessui/react';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import { getKakaoCallbackUrl } from '@/lib/env';
 import { Fragment, useCallback, useMemo, useState } from 'react';
 import { CTAButton } from '../ui/cta-button';
 
@@ -16,15 +17,11 @@ export function LoginModal({ open, onClose }: LoginModalProps) {
 
   const handleLogin = useCallback(async () => {
     setLoading(true);
-    const origin =
-      process.env.NEXTAUTH_URL ?? process.env.NEXT_PUBLIC_SITE_URL ?? window.location.origin;
-    const cleanOrigin = origin.endsWith('/') ? origin.slice(0, -1) : origin;
-
     try {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'kakao',
         options: {
-          redirectTo: `${cleanOrigin}/auth/callback`,
+          redirectTo: getKakaoCallbackUrl(),
           queryParams: {
             scope: 'account_email'
           }

--- a/docs/모듈별 상세 개발정의서.md
+++ b/docs/모듈별 상세 개발정의서.md
@@ -4,7 +4,7 @@
 - **OAuth Provider**: Kakao (`provider: 'kakao'`)
 - **초기화**: `createClientComponentClient` (client), `createServerComponentClient` (server), `createRouteHandlerClient` (route).
 - **회원 데이터 저장**: `users` 테이블 (RLS on). 키 필드 `auth_id` 고정, `full_name`, `email`, `phone` upsert.
-- **콜백 처리**: `/auth/callback`에서 코드 교환 및 사용자 동기화.
+- **콜백 처리**: `/api/auth/callback/kakao`에서 코드 교환 및 사용자 동기화.
 - **세션 흐름**: 로그인 성공 → 자동 회원가입 → 세션 쿠키 발급 → 루트/로그인 페이지에서 환영 메시지 렌더링.
 - **로그아웃**: `supabase.auth.signOut()` 호출 후 `router.refresh()`로 UI 상태 갱신.
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,77 @@
+const DEV_BASE_URL = 'http://localhost:3002';
+
+function trimTrailingSlash(url: string) {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+function resolveExplicitBaseUrl(url: string) {
+  try {
+    const parsed = new URL(url);
+    return trimTrailingSlash(parsed.origin);
+  } catch (error) {
+    throw new Error(
+      `NEXTAUTH_URL must be a valid absolute URL. Received: "${url}". ${(error as Error).message}`
+    );
+  }
+}
+
+export function assertNextAuthEnv() {
+  if (process.env.NODE_ENV !== 'production') {
+    return;
+  }
+
+  const nextAuthUrl = process.env.NEXTAUTH_URL;
+  const nextAuthSecret = process.env.NEXTAUTH_SECRET;
+
+  if (!nextAuthUrl) {
+    throw new Error('NEXTAUTH_URL must be configured in production environments.');
+  }
+
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(nextAuthUrl);
+  } catch (error) {
+    throw new Error(
+      `NEXTAUTH_URL must be a valid absolute URL. Received: "${nextAuthUrl}". ${(error as Error).message}`
+    );
+  }
+
+  if (parsedUrl.hostname === 'localhost' || parsedUrl.hostname === '127.0.0.1') {
+    throw new Error('NEXTAUTH_URL cannot point to localhost in production.');
+  }
+
+  if (!nextAuthSecret) {
+    throw new Error('NEXTAUTH_SECRET must be configured in production environments.');
+  }
+}
+
+export function getAppBaseUrl() {
+  const explicit = process.env.NEXTAUTH_URL;
+
+  if (explicit) {
+    try {
+      return resolveExplicitBaseUrl(explicit);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return trimTrailingSlash(window.location.origin);
+  }
+
+  if (process.env.VERCEL_URL) {
+    return trimTrailingSlash(`https://${process.env.VERCEL_URL}`);
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    return DEV_BASE_URL;
+  }
+
+  throw new Error('Unable to resolve application base URL. Ensure NEXTAUTH_URL is configured.');
+}
+
+export function getKakaoCallbackUrl() {
+  return `${getAppBaseUrl()}/api/auth/callback/kakao`;
+}


### PR DESCRIPTION
## Summary
- move the Supabase OAuth callback handler to `/api/auth/callback/kakao` and assert production NEXTAUTH env values
- add a shared helper for resolving the app base URL from NEXTAUTH settings and reuse it for Kakao sign-in redirects
- update the Kakao login UI and docs to point at the new callback endpoint

## Testing
- npm run lint *(fails: command prompts for interactive ESLint setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e887fc4c8323a9c5456a58ec76ab