### PR TITLE
fix: guard Kakao user phone fallback

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -37,6 +37,22 @@ function extractProfileDetails(profile?: unknown) {
   };
 }
 
+function resolveUserPhone(user: unknown) {
+  if (!user || typeof user !== 'object') {
+    return null;
+  }
+
+  if ('phone' in user) {
+    const phoneValue = (user as { phone?: unknown }).phone;
+
+    if (typeof phoneValue === 'string' || phoneValue === null) {
+      return phoneValue;
+    }
+  }
+
+  return null;
+}
+
 export const authOptions: NextAuthOptions = {
   secret: ensureEnv('NEXTAUTH_SECRET'),
   providers: [
@@ -95,7 +111,7 @@ export const authOptions: NextAuthOptions = {
               auth_id: authId,
               email: email ?? user.email ?? null,
               full_name: name ?? user.name ?? null,
-              phone: phone ?? (user as Record<string, string | null | undefined>).phone ?? null
+              phone: phone ?? resolveUserPhone(user)
             },
             { onConflict: 'auth_id' }
           );


### PR DESCRIPTION
## Summary
- add a helper to safely read the optional phone value from NextAuth users
- reuse the helper when syncing Kakao profiles to Supabase to avoid unsafe casts

## Testing
- npm run build *(fails: unable to download Google Fonts and missing `next-auth/react` during bundling in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f821fbe48323812a98d97fb26e71