### PR TITLE
docs: add folder structure reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-Source lives in `app/` (Next.js 14 app router) with domain-specific route groups derived from `docs/project_spec.md`. Shared UI sits in `components/` and follows the shadcn/TweakCN theme tokens. Non-UI logic and Supabase accessors belong to `lib/` and `supabase/` respectively; keep SQL policies alongside RLS notes from `docs/모듈별 상세 개발정의서.md`. Static assets stay under `public/`. Write Vitest suites in `tests/unit`, Playwright scenarios in `tests/e2e`, and keep architectural notes inside `docs/` with versioned headers.
+Source lives in `app/` (Next.js 14 app router) with domain-specific route groups derived from `docs/project_spec.md`. Shared UI sits in `components/` and follows the shadcn/TweakCN theme tokens. Non-UI logic and Supabase accessors belong to `lib/` and `supabase/` respectively; keep SQL policies alongside RLS notes from `docs/모듈별 상세 개발정의서.md`. Static assets stay under `public/`. Write Vitest suites in `tests/unit`, Playwright scenarios in `tests/e2e`, and keep architectural notes inside `docs/` with versioned headers. For a quick visual of the workspace layout, review `docs/folder-structure.md` before reorganizing files.
 
 ## Build, Test, and Development Commands
 Install dependencies with `npm install` (or `pnpm install` if already set up). `npm run dev` launches the local Next.js server with Tailwind hot reload. `npm run lint` runs ESLint/Prettier. `npm run build` generates the production bundle that Vercel deploys. `npm run test:unit` executes Vitest, while `npm run test:e2e` (Playwright) targets the staged build; both must pass before opening a PR. Use `npm run test` to run the full suite. Trigger a Vercel preview by pushing to any feature branch.

--- a/agent.md
+++ b/agent.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-Source lives in `app/` (Next.js 14 app router) with domain-specific route groups derived from `docs/project_spec.md`. Shared UI sits in `components/` and follows the shadcn/TweakCN theme tokens. Non-UI logic and Supabase accessors belong to `lib/` and `supabase/` respectively; keep SQL policies alongside RLS notes from `docs/모듈별 상세 개발정의서.md`. Static assets stay under `public/`. Write Vitest suites in `tests/unit`, Playwright scenarios in `tests/e2e`, and keep architectural notes inside `docs/` with versioned headers.
+Source lives in `app/` (Next.js 14 app router) with domain-specific route groups derived from `docs/project_spec.md`. Shared UI sits in `components/` and follows the shadcn/TweakCN theme tokens. Non-UI logic and Supabase accessors belong to `lib/` and `supabase/` respectively; keep SQL policies alongside RLS notes from `docs/모듈별 상세 개발정의서.md`. Static assets stay under `public/`. Write Vitest suites in `tests/unit`, Playwright scenarios in `tests/e2e`, and keep architectural notes inside `docs/` with versioned headers. For a quick visual of the workspace layout, review `docs/folder-structure.md` before reorganizing files.
 
 ## Build, Test, and Development Commands
 Install dependencies with `npm install` (or `pnpm install` if already set up). `npm run dev` launches the local Next.js server with Tailwind hot reload. `npm run lint` runs ESLint/Prettier. `npm run build` generates the production bundle that Vercel deploys. `npm run test:unit` executes Vitest, while `npm run test:e2e` (Playwright) targets the staged build; both must pass before opening a PR. Use `npm run test` to run the full suite. Trigger a Vercel preview by pushing to any feature branch.

--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -1,0 +1,56 @@
+# Folder Structure
+
+This document outlines the key directories and configuration files in the `archLegal` repository.
+
+```text
+archLegal/
+├── app/
+│   ├── (auth)/
+│   ├── (marketing)/
+│   ├── auth/
+│   ├── globals.css
+│   ├── layout.tsx
+│   └── page.tsx
+├── components/
+│   ├── auth/
+│   ├── landing/
+│   ├── layout/
+│   ├── providers/
+│   └── ui/
+├── docs/
+│   └── folder-structure.md
+├── lib/
+├── public/
+│   └── docu/
+├── supabase/
+├── types/
+├── components.json
+├── next-env.d.ts
+├── next.config.mjs
+├── package.json
+├── postcss.config.js
+├── tailwind.config.ts
+└── tsconfig.json
+```
+
+## Directory Notes
+
+- **app/** – Next.js App Router entrypoint containing route groups and global styling.
+- **components/** – Shared UI building blocks organized by domain (auth, landing, layout, providers, and shadcn-based UI primitives).
+- **docs/** – Project documentation, including this folder structure reference.
+- **lib/** – Reusable non-UI utilities and Supabase access helpers.
+- **public/** – Static assets served directly, including documentation imagery under `public/docu/`.
+- **supabase/** – Supabase configuration, migrations, and related SQL policies.
+- **types/** – Shared TypeScript type definitions consumed across the project.
+
+## Configuration Files
+
+- **components.json** – shadcn UI configuration synced with the TweakCN theme.
+- **next.config.mjs** – Next.js runtime configuration.
+- **postcss.config.js** – PostCSS plugins (Tailwind CSS, autoprefixer, etc.).
+- **tailwind.config.ts** – Tailwind CSS theme definitions aligned with TweakCN tokens.
+- **tsconfig.json** – TypeScript compiler options for the workspace.
+- **next-env.d.ts** – Next.js ambient type declarations (auto-generated).
+- **package.json** – Project dependencies and npm scripts.
+
+Refer back to this document whenever you need a quick overview of where features or assets should reside.


### PR DESCRIPTION
## Summary
- add a folder structure overview document under docs for quick repository orientation
- update repository guidelines to point contributors to the new reference

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d6508da46483239ae30c9d1aa394e2